### PR TITLE
feat: adiciona modulo de comunicaçao com servidor websocket

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+WEBSOCKET_SERVER=ws://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Thumbs.db
 Desktop.ini
 $RECYCLE.BIN/
 /config.json
+.env

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
   "license": "MIT",
   "dependencies": {
     "delay": "^5.0.0",
+    "dotenv": "^10.0.0",
     "fs-extra": "^9.1.0",
     "minimist": "^1.2.5",
-    "puppeteer": "^2.0.0"
+    "puppeteer": "^2.0.0",
+    "ws": "^8.2.1"
   }
 }

--- a/src/control.js
+++ b/src/control.js
@@ -1,0 +1,19 @@
+require('dotenv').config()
+const WebSocket = require('ws');
+
+function control() {
+    const ws = new WebSocket(process.env.WEBSOCKET_SERVER);
+
+    ws.onmessage = function (event) {
+        const data = JSON.parse(event.data);
+
+        if (data.action == "ping") {
+            ws.send(JSON.stringify({
+                action: "pong",
+                uuid: "9833a966-fe3e-4c5d-94ab-f7e2a0670e04"
+            }))
+        }
+    }
+}
+
+module.exports = control


### PR DESCRIPTION
Adicionei uma função que se conecta com um servidor websocket e envia mensagens como solicitado na issue. O `.env.example` foi adicionado para ser possível buscar a URL do servidor nele.

Para testar é necessario adicionar a URL de um servidor websocket que vá enviar mensagens como descritas na issue para a aplicação ao `.env` e executar a função `control`.

Fix: #3 