### PR TITLE
add: take screenshot (preview)

### DIFF
--- a/src/obsConnection.js
+++ b/src/obsConnection.js
@@ -1,4 +1,5 @@
 const OBSWebSocket   = require('obs-websocket-js');
+const { connect } = require('puppeteer');
 
 class obsConnection{
     constructor(address, password) {
@@ -163,6 +164,16 @@ class obsConnection{
 
     async listOutputs() {
         return this.obs.send("ListOutputs");
+    }
+
+    async takeSourceScreenshot( embedPictureFormat=null, compressionQuality=-1, width=null, height=null) {
+        return this.obs.send("TakeSourceScreenshot", {
+            embedPictureFormat: embedPictureFormat,
+            compressionQuality: compressionQuality,
+            width: width,
+            height: height
+        });
+        // Retorno do data.img contém o frame de preview codificado na base 64, apenas adicionar a um src de uma tag <img>
     }
 
     async setStreamSettings(platform, key, use_auth=false, username, password){


### PR DESCRIPTION
Nesta issue, foi adicionado um método na classe que gera um preview do que está rodando em determinada cena do obs.O screenshot é retornado no formato que desejar (selecionar pelos parâmetros) usando a base 64. 

Para aplicar a imagem em uma página na web basta usar `<img src={data.img}>` **obs**: data é o retorno da chamada do método.

Para a atualização de quadros, é possível usar um `setTimeout` para setar a taxa de atualização do preview. No exemplo que eu vi foi utilizado 1 segundo de intervalo a cada frame.

Fix: #10 