### PR TITLE
feat: adiciona conexao websocket utilizando o laravel echo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,10 @@
 WEBSOCKET_SERVER=ws://localhost:3000
 GOOGLE_EMAIL=username@gmail.com
 GOOGLE_PASSWORD=password
+
+WS_HOST=localhost
+WS_PORT=6001
+WSS_PORT=6001
+
+PUSHER_APP_KEY=test
+PUSHER_APP_CLUSTER=mt1

--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
     "delay": "^5.0.0",
     "dotenv": "^10.0.0",
     "fs-extra": "^9.1.0",
+    "laravel-echo": "^1.11.2",
     "minimist": "^1.2.5",
+    "obs-websocket-js": "^4.0.3",
     "puppeteer": "^2.0.0",
-    "ws": "^8.2.1",
     "puppeteer-extra": "^3.1.18",
     "puppeteer-extra-plugin-stealth": "^2.7.8",
-    "obs-websocket-js": "^4.0.3"
+    "pusher-js": "^7.0.3"
   }
 }

--- a/src/control.js
+++ b/src/control.js
@@ -1,19 +1,31 @@
-require('dotenv').config()
-const WebSocket = require('ws');
+require('dotenv').config();
+const Echo = require('laravel-echo');
+Pusher =  require('pusher-js');
 
 function control() {
-    const ws = new WebSocket(process.env.WEBSOCKET_SERVER);
+    const echo = new Echo({
+        broadcaster: 'pusher',
+        key: process.env.PUSHER_APP_KEY,
+        wsHost: process.env.WS_HOST,
+        wsPort: process.env.WS_PORT,
+        wssPort: process.env.WSS_PORT,
+        cluster: process.env.PUSHER_APP_CLUSTER,
+        forceTLS: false,
+        disableStats: true,
+    });
 
-    ws.onmessage = function (event) {
-        const data = JSON.parse(event.data);
+    echo.connector.pusher.connection.bind('connected', () => {
+        console.log('\033[0;32mConnection opened\u001b[0m');
+    });
 
-        if (data.action == "ping") {
-            ws.send(JSON.stringify({
-                action: "pong",
-                uuid: "9833a966-fe3e-4c5d-94ab-f7e2a0670e04"
-            }))
-        }
-    }
+    echo.connector.pusher.connection.bind('disconnected', () => {
+        console.log('Connection closed');
+    });
+
+    echo.channel('streamer-channel')
+    .listen('.example-event', (e) => {
+        console.log(e);
+    });
 }
 
 module.exports = control


### PR DESCRIPTION
Para testar é necessario adicionar as configurações novas ao `.env` (já deixei o .env.example com as configurações padrão do projeto live-web), além disso é necessario clonar e configurar o projeto do live-web para poder disparar um evento. É possível utilizar o código e instruções [deste pull request](https://github.com/practice-uffs/live-web/pull/2) para enviar um evento.

Os eventos são capturados por um bloco de código no formato:
``` 
echo.channel('channel-name').listen('.event-name', (e) => {
    console.log(e);
});
```
No momento, deixei como exemplo um bloco que captura e mostra na tela um evento com nome `example-event`

Fix: #11 